### PR TITLE
Don't require node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@symfony/webpack-encore": "^0.30.2",
     "lit": "^2.0.0-rc.3",
-    "node": "^14.17.4",
+    "node": ">=14.17.4",
     "remove-files-webpack-plugin": "^1.4.4",
     "sass": "^1.44.0",
     "sass-loader": "^8.0.2"


### PR DESCRIPTION
We'd like to use this module, but need to use a later version of node. In our tests, changing this dependency to allow node 16 didn't have any negative impact.