### PR TITLE
Patch v2.16: Add img role to footer wordmark

### DIFF
--- a/src/js/components/footer/footer.component.js
+++ b/src/js/components/footer/footer.component.js
@@ -8,7 +8,7 @@ class Footer extends LitElement {
 
     renderWordmark() {
         return html`
-<svg class="wordmark" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 300.9 78.2" xml:space="preserve">
+<svg class="wordmark" role="img" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 300.9 78.2" xml:space="preserve">
     <title>University of Illinois Urbana-Champaign</title>
     <g class="block-i">
         <path class="block-i__outline" d="M54.2 21.1V0H0v21.1h12v36.1H0v21.1h54.2V57.2h-12V21.1h12zM42.1 60.2h9v15H3v-15h9c1.7 0 3-1.3 3-3V21.1c0-1.7-1.3-3-3-3H3V3h48.1v15h-9c-1.7 0-3 1.3-3 3v36.1c0 1.7 1.4 3.1 3 3.1"/>


### PR DESCRIPTION
## Summary

- adds an `img` aria role to the wordmark in the footer component (closes #536)
- patches release/2.16

## Testing

1. Install PR branch
2. Load footer component in browser
3. Run AInspector or comparable tool on dev page. Footer wordmark should pass automated checks in the Aria-Widgets category and require a manual check in the Images category

## Merge Instructions

- merge PR branch to release/2.16
- merge release/2.16 to main